### PR TITLE
ci: Enable CI workflow to run on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Add pull_request trigger to ci.yml so that tests run on PR creation and updates, providing CI feedback on all proposed changes before merging to main.

Changes:
- Add pull_request trigger for main branch
- CI tests and build will now run on all PRs targeting main