### PR TITLE
ci: Enable CI workflow to run on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
 
   deploy:
     needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
## Summary

- Add pull_request trigger to ci.yml for test execution on all PRs
- Restrict deploy job to main branch pushes only

## Changes

**Commit 1:** Enable CI workflow to run on pull requests
- Add `pull_request: branches: [main]` trigger
- CI tests now run on PR creation and updates

**Commit 2:** Restrict deploy job to main branch only
- Add condition: `if: github.event_name == 'push' && github.ref == 'refs/heads/main'`
- Deploy only runs on pushes to main, not on PRs

## Test plan

- [ ] Create PR to verify tests run on pull requests
- [ ] Merge to main and verify deploy job executes
- [ ] Verify deploy does not run on future PRs
